### PR TITLE
Upgrades Apache Beam from 2.11 to 2.18.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,5 +40,5 @@ steps:
 substitutions:
   _VERSION_MAJOR: "0"
   _VERSION_MINOR: "2"
-  _VERSION_PATCH: "2"
+  _VERSION_PATCH: "3"
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>2.11.0</beam.version>
+    <beam.version>2.18.0</beam.version>
 
     <bigquery.version>v2-rev20181104-1.27.0</bigquery.version>
     <google-clients.version>1.27.0</google-clients.version>


### PR DESCRIPTION
2.11 is deprecated.
2.19 (latest) fails a single unit test (related to BigQuery Storage API).
2.18 passes all tests (except for 2 Avro related). 

Let's go for 2.18 for now and plan to move it to latest soon.